### PR TITLE
feat: AI PR Review with multi-LLM support (Claude/OpenAI/DeepSeek)

### DIFF
--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -1,0 +1,323 @@
+"""AI PR Review - Automated code review using LLM."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+API_URL = os.environ.get("GITHUB_API_URL", "")
+REPO = os.environ.get("REPOSITORY", "")
+PR_NUMBER = int(os.environ.get("PR_NUMBER", "0"))
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+REVIEW_LEVEL = os.environ.get("REVIEW_LEVEL", "standard")
+MAX_DIFF_LINES = int(os.environ.get("MAX_DIFF_LINES", "4000"))
+
+LLM_PROVIDER = os.environ.get("LLM_PROVIDER", "deepseek").lower()
+
+PROVIDERS = {
+    "anthropic": {
+        "api_key_env": "ANTHROPIC_API_KEY",
+        "model": "claude-sonnet-4-20250514",
+    },
+    "openai": {
+        "api_key_env": "OPENAI_API_KEY",
+        "base_url": "https://api.openai.com/v1",
+        "model": "gpt-4o",
+    },
+    "deepseek": {
+        "api_key_env": "DEEPSEEK_API_KEY",
+        "base_url": "https://api.deepseek.com/v1",
+        "model": "deepseek-chat",
+    },
+}
+
+
+def _gh_client() -> httpx.Client:
+    return httpx.Client(
+        base_url=API_URL,
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github.v3+json",
+        },
+        timeout=30,
+    )
+
+
+GH = _gh_client()
+
+
+# ── GitHub helpers ─────────────────────────────────────────────
+
+def get_pr_diff() -> str:
+    r = GH.get(f"/repos/{REPO}/pulls/{PR_NUMBER}", headers={"Accept": "application/vnd.github.v3.diff"})
+    r.raise_for_status()
+    return r.text
+
+
+def get_changed_files() -> list[dict]:
+    r = GH.get(f"/repos/{REPO}/pulls/{PR_NUMBER}/files")
+    r.raise_for_status()
+    return r.json()
+
+
+def get_file_content(path: str, ref: str) -> str | None:
+    r = GH.get(f"/repos/{REPO}/contents/{path}", params={"ref": ref})
+    if r.status_code != 200:
+        return None
+    import base64
+    return base64.b64decode(r.json()["content"]).decode("utf-8", errors="replace")
+
+
+def post_review(body: str, comments: list[dict]):
+    payload = {
+        "body": body,
+        "event": "COMMENT",
+        "comments": comments,
+    }
+    r = GH.post(f"/repos/{REPO}/pulls/{PR_NUMBER}/reviews", json=payload)
+    if r.status_code in (200, 201):
+        print(f"Review posted ({len(comments)} inline comments)")
+    else:
+        print(f"Failed to post review: {r.status_code} {r.text}", file=sys.stderr)
+        # Fallback: post as a single PR comment
+        fallback = body
+        if comments:
+            fallback += "\n\n---\n### Inline Comments\n"
+            for c in comments:
+                fallback += f"\n**`{c['path']}:{c.get('line', '?')}`** — {c['body']}\n"
+        GH.post(
+            f"/repos/{REPO}/issues/{PR_NUMBER}/comments",
+            json={"body": fallback},
+        )
+        print("Posted as fallback issue comment.")
+
+
+# ── LLM helpers ────────────────────────────────────────────────
+
+SYSTEM_PROMPT = """\
+You are a senior code reviewer for the socitwin project — a social media simulation platform
+with a Python/FastAPI backend (async, Pydantic, SQLite, CAMEL-AI/OASIS for LLM integration)
+and a React/TypeScript frontend (Vite, Tailwind, D3.js, Zustand, Socket.io).
+
+Review the PR diff below. Respond with a JSON object having exactly these keys:
+
+{
+  "summary": "1-3 sentence overall assessment",
+  "comments": [
+    {
+      "path": "relative/file/path.py",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "markdown comment body"
+    }
+  ]
+}
+
+## Review severity levels
+
+Each comment must start with one of these markers:
+- 🔴 **Critical** — Security holes, data loss, crashes, injection, hardcoded secrets
+- ⚠️ **Warning** — Logic errors, resource leaks, missing validation, race conditions
+- 💡 **Suggestion** — Naming, readability, testability, documentation, minor improvements
+- ✅ **Looks Good** — Notable good patterns worth highlighting
+
+## Project-specific checks
+
+Backend (Python/FastAPI):
+- Route functions must have error handling
+- Database operations must use parameterized queries / ORM
+- LLM API calls must have timeout + retry
+- Pydantic schemas must validate input
+- Async functions must not mix blocking I/O
+
+Frontend (React/TypeScript):
+- API calls need error boundary handling
+- Watch for memory leaks (unsubscribed listeners, dangling intervals)
+- No hardcoded secrets or console.log with sensitive data
+- Proper TypeScript typing (avoid `any`)
+
+General:
+- New code should include tests
+- Config files (.env, lock files) should not be changed without reason
+- PR should reference related issues
+
+## Rules
+- Be concise. Each comment: max 6 lines.
+- Only comment on lines present in the diff. Use RIGHT side line numbers.
+- Skip generated files, lock files, and vendored code.
+- If the diff is clean, return an empty comments array and a positive summary.
+- Output ONLY the JSON object, nothing else.
+"""
+
+
+def build_prompt(diff: str, extra_context: str) -> str:
+    level_hint = "Be thorough and strict — flag even minor issues." if REVIEW_LEVEL == "strict" else "Focus on significant issues. Skip nitpicks."
+    return f"""\
+Review level: {REVIEW_LEVEL}. {level_hint}
+
+## PR Diff
+```diff
+{diff}
+```
+
+{extra_context}
+"""
+
+
+def chunk_diff(diff: str, max_lines: int = MAX_DIFF_LINES) -> list[str]:
+    lines = diff.splitlines()
+    if len(lines) <= max_lines:
+        return [diff]
+    chunks = []
+    for i in range(0, len(lines), max_lines):
+        chunks.append("\n".join(lines[i : i + max_lines]))
+    return chunks
+
+
+def _parse_llm_json(text: str) -> dict:
+    """Extract JSON from LLM response, stripping code fences if present."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1]
+        text = text.rsplit("```", 1)[0]
+    return json.loads(text.strip())
+
+
+def _get_api_key(provider: str) -> str:
+    cfg = PROVIDERS[provider]
+    return os.environ.get(cfg["api_key_env"], "")
+
+
+def call_llm(prompt: str) -> dict:
+    if LLM_PROVIDER not in PROVIDERS:
+        return {"summary": f"⚠️ Unknown LLM_PROVIDER `{LLM_PROVIDER}`. Choose from: {', '.join(PROVIDERS)}", "comments": []}
+
+    api_key = _get_api_key(LLM_PROVIDER)
+    if not api_key:
+        env_name = PROVIDERS[LLM_PROVIDER]["api_key_env"]
+        return {"summary": f"⚠️ {env_name} not configured. Skipping AI review.", "comments": []}
+
+    if LLM_PROVIDER == "anthropic":
+        return _call_anthropic(api_key, prompt)
+    return _call_openai_compatible(api_key, prompt)
+
+
+def _call_anthropic(api_key: str, prompt: str) -> dict:
+    r = httpx.post(
+        "https://api.anthropic.com/v1/messages",
+        headers={
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+        json={
+            "model": PROVIDERS["anthropic"]["model"],
+            "max_tokens": 4096,
+            "system": SYSTEM_PROMPT,
+            "messages": [{"role": "user", "content": prompt}],
+        },
+        timeout=120,
+    )
+    r.raise_for_status()
+    text = r.json()["content"][0]["text"]
+    return _parse_llm_json(text)
+
+
+def _call_openai_compatible(api_key: str, prompt: str) -> dict:
+    cfg = PROVIDERS[LLM_PROVIDER]
+    r = httpx.post(
+        f"{cfg['base_url']}/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": cfg["model"],
+            "max_tokens": 4096,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        },
+        timeout=120,
+    )
+    r.raise_for_status()
+    text = r.json()["choices"][0]["message"]["content"]
+    return _parse_llm_json(text)
+
+
+# ── Main flow ──────────────────────────────────────────────────
+
+def main():
+    print(f"Reviewing PR #{PR_NUMBER} in {REPO} (provider: {LLM_PROVIDER}, level: {REVIEW_LEVEL})")
+
+    diff = get_pr_diff()
+    if not diff.strip():
+        print("Empty diff, nothing to review.")
+        return
+
+    # Build extra context from changed files
+    changed = get_changed_files()
+    ext_context = ""
+    reviewable = [
+        f for f in changed
+        if not any(
+            f["filename"].endswith(ext)
+            for ext in (".lock", ".map", ".min.js", ".min.css")
+        )
+        and "node_modules" not in f["filename"]
+        and "vendor" not in f["filename"]
+    ]
+    if reviewable:
+        ext_context = "## Changed files\n"
+        for f in reviewable:
+            ext_context += f"- `{f['filename']}` (+{f['additions']} -{f['deletions']})\n"
+
+    print(f"Diff: {len(diff.splitlines())} lines, {len(reviewable)} reviewable files")
+
+    chunks = chunk_diff(diff)
+    all_comments: list[dict] = []
+    summary_parts: list[str] = []
+
+    for i, chunk in enumerate(chunks):
+        print(f"Reviewing chunk {i + 1}/{len(chunks)}...")
+        ctx = ext_context if i == 0 else ""
+        prompt = build_prompt(chunk, ctx)
+        try:
+            result = call_llm(prompt)
+        except Exception as e:
+            print(f"LLM call failed for chunk {i + 1}: {e}", file=sys.stderr)
+            summary_parts.append(f"⚠️ Chunk {i + 1} review failed: {e}")
+            continue
+
+        summary_parts.append(result.get("summary", ""))
+        all_comments.extend(result.get("comments", []))
+
+    if not all_comments and not summary_parts:
+        print("No review output.")
+        return
+
+    # Validate comment positions against changed files
+    valid_paths = {f["filename"] for f in changed}
+    valid_comments = [
+        c for c in all_comments
+        if c.get("path", "") in valid_paths
+    ]
+    skipped = len(all_comments) - len(valid_comments)
+    if skipped:
+        print(f"Skipped {skipped} comments with invalid file paths")
+
+    summary = "\n\n".join(s for s in summary_parts if s)
+    # Prepend metadata header
+    header = f"## 🤖 AI Code Review (`{LLM_PROVIDER}` · `{REVIEW_LEVEL}`)\n\n"
+    body = header + summary
+    if chunks:
+        body += f"\n\n_Reviewed in {len(chunks)} chunk(s). {len(valid_comments)} finding(s)._"
+
+    post_review(body, valid_comments)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -29,7 +29,7 @@ PROVIDERS = {
     "deepseek": {
         "api_key_env": "DEEPSEEK_API_KEY",
         "base_url": "https://api.deepseek.com/v1",
-        "model": "deepseek-chat",
+        "model": "deepseek-reasoner",
     },
     "deepseek-v3": {
         "api_key_env": "DEEPSEEK_API_KEY",

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -31,6 +31,11 @@ PROVIDERS = {
         "base_url": "https://api.deepseek.com/v1",
         "model": "deepseek-chat",
     },
+    "deepseek-v3": {
+        "api_key_env": "DEEPSEEK_API_KEY",
+        "base_url": "https://api.deepseek.com/v1",
+        "model": "deepseek-v3",
+    },
 }
 
 
@@ -84,7 +89,7 @@ def post_review(body: str, comments: list[dict]):
         # Fallback: post as a single PR comment
         fallback = body
         if comments:
-            fallback += "\n\n---\n### Inline Comments\n"
+            fallback += "\n\n---\n### 行内评论\n"
             for c in comments:
                 fallback += f"\n**`{c['path']}:{c.get('line', '?')}`** — {c['body']}\n"
         GH.post(
@@ -97,65 +102,65 @@ def post_review(body: str, comments: list[dict]):
 # ── LLM helpers ────────────────────────────────────────────────
 
 SYSTEM_PROMPT = """\
-You are a senior code reviewer for the socitwin project — a social media simulation platform
-with a Python/FastAPI backend (async, Pydantic, SQLite, CAMEL-AI/OASIS for LLM integration)
-and a React/TypeScript frontend (Vite, Tailwind, D3.js, Zustand, Socket.io).
+你是 socitwin 项目的高级代码审查员 — 这是一个社交媒体模拟平台
+后端采用 Python/FastAPI (async, Pydantic, SQLite, CAMEL-AI/OASIS 用于 LLM 集成)
+前端采用 React/TypeScript (Vite, Tailwind, D3.js, Zustand, Socket.io)。
 
-Review the PR diff below. Respond with a JSON object having exactly these keys:
+审查以下 PR diff。请返回一个 JSON 对象，格式如下：
 
 {
-  "summary": "1-3 sentence overall assessment",
+  "summary": "1-3 句话的总体评价",
   "comments": [
     {
       "path": "relative/file/path.py",
       "line": 42,
       "side": "RIGHT",
-      "body": "markdown comment body"
+      "body": "markdown 格式的评论内容"
     }
   ]
 }
 
-## Review severity levels
+## 审查严重级别
 
-Each comment must start with one of these markers:
-- 🔴 **Critical** — Security holes, data loss, crashes, injection, hardcoded secrets
-- ⚠️ **Warning** — Logic errors, resource leaks, missing validation, race conditions
-- 💡 **Suggestion** — Naming, readability, testability, documentation, minor improvements
-- ✅ **Looks Good** — Notable good patterns worth highlighting
+每条评论必须以以下标记之一开头：
+- 🔴 **Critical** — 安全漏洞、数据丢失、崩溃、注入攻击、硬编码密钥
+- ⚠️ **Warning** — 逻辑错误、资源泄漏、缺失校验、竞态条件
+- 💡 **Suggestion** — 命名规范、可读性、可测试性、文档建议、小改进
+- ✅ **Looks Good** — 值得肯定的良好实践
 
-## Project-specific checks
+## 项目专项检查
 
-Backend (Python/FastAPI):
-- Route functions must have error handling
-- Database operations must use parameterized queries / ORM
-- LLM API calls must have timeout + retry
-- Pydantic schemas must validate input
-- Async functions must not mix blocking I/O
+后端 (Python/FastAPI)：
+- 路由函数必须有异常处理
+- 数据库操作必须使用参数化查询 / ORM
+- LLM API 调用必须有超时和重试机制
+- Pydantic schema 必须校验输入
+- 异步函数不能混用阻塞 I/O
 
-Frontend (React/TypeScript):
-- API calls need error boundary handling
-- Watch for memory leaks (unsubscribed listeners, dangling intervals)
-- No hardcoded secrets or console.log with sensitive data
-- Proper TypeScript typing (avoid `any`)
+前端 (React/TypeScript)：
+- API 调用需要错误边界处理
+- 注意内存泄漏（未清理的监听器、定时器）
+- 不能硬编码密钥或用 console.log 输出敏感数据
+- 正确的 TypeScript 类型（避免使用 `any`）
 
-General:
-- New code should include tests
-- Config files (.env, lock files) should not be changed without reason
-- PR should reference related issues
+通用：
+- 新增代码应包含测试
+- 配置文件（.env, lock 文件）不应无故修改
+- PR 应关联相关 issue
 
-## Rules
-- Be concise. Each comment: max 6 lines.
-- Only comment on lines present in the diff. Use RIGHT side line numbers.
-- Skip generated files, lock files, and vendored code.
-- If the diff is clean, return an empty comments array and a positive summary.
-- Output ONLY the JSON object, nothing else.
+## 规则
+- 简洁明了。每条评论最多 6 行。
+- 只评论 diff 中出现的行。使用 RIGHT 侧行号。
+- 跳过生成文件、lock 文件和第三方代码。
+- 如果 diff 很干净，返回空的 comments 数组和正面评价的 summary。
+- 只输出 JSON 对象，不要输出其他内容。
 """
 
 
 def build_prompt(diff: str, extra_context: str) -> str:
-    level_hint = "Be thorough and strict — flag even minor issues." if REVIEW_LEVEL == "strict" else "Focus on significant issues. Skip nitpicks."
+    level_hint = "严格模式 — 标记所有问题，包括小问题。" if REVIEW_LEVEL == "strict" else "标准模式 — 重点关注显著问题，忽略吹毛求疵。"
     return f"""\
-Review level: {REVIEW_LEVEL}. {level_hint}
+审查强度: {REVIEW_LEVEL}。{level_hint}
 
 ## PR Diff
 ```diff
@@ -192,12 +197,12 @@ def _get_api_key(provider: str) -> str:
 
 def call_llm(prompt: str) -> dict:
     if LLM_PROVIDER not in PROVIDERS:
-        return {"summary": f"⚠️ Unknown LLM_PROVIDER `{LLM_PROVIDER}`. Choose from: {', '.join(PROVIDERS)}", "comments": []}
+        return {"summary": f"⚠️ 未知的 LLM_PROVIDER `{LLM_PROVIDER}`。可选: {', '.join(PROVIDERS)}", "comments": []}
 
     api_key = _get_api_key(LLM_PROVIDER)
     if not api_key:
         env_name = PROVIDERS[LLM_PROVIDER]["api_key_env"]
-        return {"summary": f"⚠️ {env_name} not configured. Skipping AI review.", "comments": []}
+        return {"summary": f"⚠️ 未配置 {env_name}。跳过 AI 审查。", "comments": []}
 
     if LLM_PROVIDER == "anthropic":
         return _call_anthropic(api_key, prompt)
@@ -251,11 +256,11 @@ def _call_openai_compatible(api_key: str, prompt: str) -> dict:
 # ── Main flow ──────────────────────────────────────────────────
 
 def main():
-    print(f"Reviewing PR #{PR_NUMBER} in {REPO} (provider: {LLM_PROVIDER}, level: {REVIEW_LEVEL})")
+    print(f"正在审查 PR #{PR_NUMBER} in {REPO} (provider: {LLM_PROVIDER}, level: {REVIEW_LEVEL})")
 
     diff = get_pr_diff()
     if not diff.strip():
-        print("Empty diff, nothing to review.")
+        print("Diff 为空，无需审查。")
         return
 
     # Build extra context from changed files
@@ -271,32 +276,32 @@ def main():
         and "vendor" not in f["filename"]
     ]
     if reviewable:
-        ext_context = "## Changed files\n"
+        ext_context = "## 变更文件\n"
         for f in reviewable:
             ext_context += f"- `{f['filename']}` (+{f['additions']} -{f['deletions']})\n"
 
-    print(f"Diff: {len(diff.splitlines())} lines, {len(reviewable)} reviewable files")
+    print(f"Diff: {len(diff.splitlines())} 行, {len(reviewable)} 个可审查文件")
 
     chunks = chunk_diff(diff)
     all_comments: list[dict] = []
     summary_parts: list[str] = []
 
     for i, chunk in enumerate(chunks):
-        print(f"Reviewing chunk {i + 1}/{len(chunks)}...")
+        print(f"正在审查第 {i + 1}/{len(chunks)} 块...")
         ctx = ext_context if i == 0 else ""
         prompt = build_prompt(chunk, ctx)
         try:
             result = call_llm(prompt)
         except Exception as e:
-            print(f"LLM call failed for chunk {i + 1}: {e}", file=sys.stderr)
-            summary_parts.append(f"⚠️ Chunk {i + 1} review failed: {e}")
+            print(f"第 {i + 1} 块 LLM 调用失败: {e}", file=sys.stderr)
+            summary_parts.append(f"⚠️ 第 {i + 1} 块审查失败: {e}")
             continue
 
         summary_parts.append(result.get("summary", ""))
         all_comments.extend(result.get("comments", []))
 
     if not all_comments and not summary_parts:
-        print("No review output.")
+        print("无审查输出。")
         return
 
     # Validate comment positions against changed files
@@ -307,14 +312,14 @@ def main():
     ]
     skipped = len(all_comments) - len(valid_comments)
     if skipped:
-        print(f"Skipped {skipped} comments with invalid file paths")
+        print(f"跳过 {skipped} 条文件路径无效的评论")
 
     summary = "\n\n".join(s for s in summary_parts if s)
     # Prepend metadata header
-    header = f"## 🤖 AI Code Review (`{LLM_PROVIDER}` · `{REVIEW_LEVEL}`)\n\n"
+    header = f"## 🤖 AI 代码审查 (`{LLM_PROVIDER}` · `{REVIEW_LEVEL}`)\n\n"
     body = header + summary
     if chunks:
-        body += f"\n\n_Reviewed in {len(chunks)} chunk(s). {len(valid_comments)} finding(s)._"
+        body += f"\n\n_分 {len(chunks)} 个块审查。共 {len(valid_comments)} 条发现。_"
 
     post_review(body, valid_comments)
 

--- a/.github/scripts/ai_review.py
+++ b/.github/scripts/ai_review.py
@@ -85,7 +85,7 @@ def post_review(body: str, comments: list[dict]):
     if r.status_code in (200, 201):
         print(f"Review posted ({len(comments)} inline comments)")
     else:
-        print(f"Failed to post review: {r.status_code} {r.text}", file=sys.stderr)
+        print(f"Failed to post review: HTTP {r.status_code}", file=sys.stderr)
         # Fallback: post as a single PR comment
         fallback = body
         if comments:
@@ -293,8 +293,11 @@ def main():
         try:
             result = call_llm(prompt)
         except Exception as e:
-            print(f"第 {i + 1} 块 LLM 调用失败: {e}", file=sys.stderr)
-            summary_parts.append(f"⚠️ 第 {i + 1} 块审查失败: {e}")
+            exc_name = type(e).__name__
+            http_status = getattr(getattr(e, 'response', None), 'status_code', None)
+            status_str = f" HTTP {http_status}" if http_status else ""
+            print(f"第 {i + 1} 块 LLM 调用失败: {exc_name}{status_str}", file=sys.stderr)
+            summary_parts.append(f"⚠️ 第 {i + 1} 块审查失败: {exc_name}{status_str}")
             continue
 
         summary_parts.append(result.get("summary", ""))

--- a/.github/scripts/pyproject.toml
+++ b/.github/scripts/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "ai-pr-review"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27",
+]

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       review_level:
-        description: 'Review intensity: standard or strict'
+        description: '审查强度: standard（标准）或 strict（严格）'
         required: false
         default: 'standard'
       llm_provider:
-        description: 'LLM provider: anthropic, openai, deepseek'
+        description: 'LLM 提供商: anthropic, openai, deepseek, deepseek-v3'
         required: false
         default: 'deepseek'
 

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run AI Review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LLM_PROVIDER: ${{ github.event.inputs.llm_provider || 'anthropic' }}
+          LLM_PROVIDER: ${{ github.event.inputs.llm_provider || 'deepseek' }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,0 +1,58 @@
+name: AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+    inputs:
+      review_level:
+        description: 'Review intensity: standard or strict'
+        required: false
+        default: 'standard'
+      llm_provider:
+        description: 'LLM provider: anthropic, openai, deepseek'
+        required: false
+        default: 'deepseek'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    # Skip draft PRs and dependabot
+    if: ${{ !github.event.pull_request.draft && github.actor != 'dependabot[bot]' }}
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        working-directory: .github/scripts
+        run: uv sync
+
+      - name: Run AI Review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LLM_PROVIDER: ${{ github.event.inputs.llm_provider || 'anthropic' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          REVIEW_LEVEL: ${{ github.event.inputs.review_level || 'standard' }}
+          MAX_DIFF_LINES: '4000'
+        working-directory: .github/scripts
+        run: uv run ai_review.py

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ skills/
 
 # Keep skills-lock.json for version tracking (use ! to negate ignore pattern)
 # !skills-lock.json
+
+# AI review script
+.github/scripts/.venv/
+.github/scripts/uv.lock


### PR DESCRIPTION
## Summary
- Add automated code review workflow that triggers on PR opened/synchronize
- Supports three LLM providers: Claude Sonnet, OpenAI GPT-4o, DeepSeek
- Provides inline code comments + summary review posted by `github-actions[bot]`
- Zero operational overhead — runs entirely in GitHub Actions

## Configuration
Add your API key to **Settings → Secrets and variables → Actions**:
- `DEEPSEEK_API_KEY` (default provider)
- `ANTHROPIC_API_KEY` (Claude)
- `OPENAI_API_KEY` (GPT-4o)

Default provider: `deepseek` (can be changed in workflow inputs)

## Review focus areas
- **Backend**: FastAPI routes, error handling, SQL injection, LLM API patterns
- **Frontend**: React error boundaries, memory leaks, TypeScript typing
- **General**: Test coverage, config file changes, issue references

## Test plan
- [x] Backend checks pass (Pyright, Ruff)
- [x] Python syntax validated
- [x] YAML workflow syntax validated
- [ ] Trigger on PR creation to verify AI review runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)