### PR TITLE
fix: add missing cachetools dependency

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "jieba>=0.42.1",
     "aiofiles>=24.0.0",
     "matplotlib>=3.7.0",
+    "cachetools>=7.0.6",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Added `cachetools>=7.0.6` to backend dependencies in `pyproject.toml`

## Problem
The `proxy_service.py` module uses `cachetools.TTLCache` for caching Baidu sentiment API results, but the dependency was not declared in `pyproject.toml`. This caused `ModuleNotFoundError: No module named 'cachetools'` when starting the uvicorn server.

## Solution
Added the missing `cachetools` dependency to fix the import error.

## Test plan
- [ ] Server starts without ModuleNotFoundError
- [ ] Proxy service loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)