### PR TITLE
feat(overview): 在态势推演v2增加了情感倾向曲线

### DIFF
--- a/frontend/src/components/SituationalAwarenessChart.tsx
+++ b/frontend/src/components/SituationalAwarenessChart.tsx
@@ -27,6 +27,7 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
     const data = chartHistory.map(h => ({
       step: h.step,
       极化: h.polarization || 0,
+      情感倾向: h.sentimentTendency ?? 0,
       从众: h.herdEffect || 0,
       传播: Math.min((h.propagation || 0) / Math.max(status.activeAgents || 1, 1), 1),
     }))
@@ -104,6 +105,16 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
             >
               <div className="w-1.5 h-1.5" style={{ background: '#00f2ff' }} /> 从众
             </span>
+            <span
+              className="flex items-center gap-2 text-[10px] font-semibold"
+              style={{
+                fontFamily: '"JetBrains Mono", monospace',
+                color: '#f59e0b',
+                letterSpacing: '0.05em',
+              }}
+            >
+              <div className="w-1.5 h-1.5" style={{ background: '#f59e0b' }} /> 情感倾向
+            </span>
           </div>
         </div>
 
@@ -123,6 +134,10 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
                 <linearGradient id="colorHerd" x1="0" y1="0" x2="0" y2="1">
                   <stop offset="0%" stopColor="#00f2ff" stopOpacity={0.3} />
                   <stop offset="100%" stopColor="#00f2ff" stopOpacity={0} />
+                </linearGradient>
+                <linearGradient id="colorSentiment" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.24} />
+                  <stop offset="100%" stopColor="#f59e0b" stopOpacity={0} />
                 </linearGradient>
               </defs>
 
@@ -149,7 +164,7 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
                 stroke="rgba(113, 113, 122, 0.5)"
                 fontSize={10}
                 fontFamily='"JetBrains Mono", monospace'
-                domain={[0, 1]}
+                domain={[-1, 1]}
                 tickCount={5}
                 tickFormatter={value => `${(value * 100).toFixed(0)}%`}
                 tick={{ fill: '#71717a' }}
@@ -211,6 +226,17 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
                 strokeWidth={1.5}
                 dot={false}
               />
+
+              {/* 情感倾向 - 琥珀黄（-1 到 1） */}
+              <Area
+                type="monotone"
+                dataKey="情感倾向"
+                stroke="#f59e0b"
+                fillOpacity={1}
+                fill="url(#colorSentiment)"
+                strokeWidth={1.5}
+                dot={false}
+              />
             </AreaChart>
           </ResponsiveContainer>
         </div>
@@ -224,7 +250,7 @@ export const SituationalAwarenessChart = ({ currentStep }: SituationalAwarenessC
             letterSpacing: '0.02em',
           }}
         >
-          * 基于数据库历史数据绘制 · X轴为模拟步数 · 指标已归一化处理
+          * 基于数据库历史数据绘制 · X轴为模拟步数 · 情感倾向范围为 -100% 到 100%
         </p>
 
         {/* 装饰性角标 */}


### PR DESCRIPTION
## 📌 概述 / Summary

在公共组件 `SituationalAwarenessChart` 中接入 `sentimentTendency` 数据，使 `/overview` 与 `/overview-v2` 两个页面的"态势分析"图同时新增一条**情感倾向曲线**。Y 轴范围相应从 `[0, 1]` 调整为 `[-1, 1]` 以支持负值情感。

Closes #<issue-number-if-any>

## 🎯 变更动机 / Motivation

之前态势分析图只展示极化 / 传播 / 从众三项指标，无法直观看到舆情情感的正负走向。本次将后端已经计算好的 `sentimentTendency` 时序数据接入到前端图表，让分析人员在同一张图里完整看到四个维度的演化趋势。

由于 `OverviewV2` 复用同一个组件，本次只需改动一处即可让两个页面同时生效，避免 V1/V2 两套图表逻辑漂移。

## 🔧 改动文件 / Changes

- **`frontend/src/components/SituationalAwarenessChart.tsx`**
  - 从 `chartHistory` 中接入 `sentimentTendency` 序列
  - 新增图例项 `情感倾向`
  - 新增一条琥珀黄色（amber）曲线及面积渐变
  - Y 轴 domain 由 `[0, 1]` → `[-1, 1]`
  - 更新组件说明文案，明确情感倾向支持负值

## 📺 影响范围 / Affected pages

| 路由 | 是否生效 | 说明 |
|---|---|---|
| `/overview` | ✅ | 复用同一组件，自动生效 |
| `/overview-v2` | ✅ | 复用同一组件，自动生效 |

未新增任何 prop 破坏性变更，调用方无需修改。

## 🖼️ 视觉变化 / Screenshots

> _请在合并前补一张前后对比截图（4 条曲线 vs 原 3 条曲线）_

- Before: 极化 / 传播 / 从众
- After:  极化 / 传播 / 从众 / **情感倾向**

## ✅ 前端检查 / Frontend checks

本地已全部跑过并通过：
